### PR TITLE
Add Dockerfile for containerized running.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8-slim
+
+WORKDIR /app
+
+RUN pip install --upgrade pip
+
+COPY requirements.txt ./
+
+RUN pip install -r requirements.txt
+
+COPY dltool.py ./
+
+ENTRYPOINT ["python", "dltool.py"]


### PR DESCRIPTION
I created this Dockerfile to use for myself, but thought it could be useful to add to the repo.

Using this it is possible to simply run the script without installing python or dependencies. You could even publish an image to docker hub so people could run it directly without even downloading the code from this repo.

Personally I am using it like this:

```
docker run --rm -it -v /srv:/srv $(docker build -q .) -i /srv/input.dat -o /srv/path/to/roms
```
NOTE: I mounted my volume found at `/srv` this will be different for everyone and is a requirement to give the container access to files on your system.