### PR TITLE
Use element name instead of rom name

### DIFF
--- a/dltool.py
+++ b/dltool.py
@@ -133,8 +133,7 @@ for datchild in datroot:
             logger(f'Processing {system}...', 'green')
     #Add found ROMs to wanted list
     elif datchild.tag == 'game':
-        rom = datchild.find('rom')
-        filename = rom.attrib['name']
+        filename = datchild.attrib['name']
         filename = re.sub(r'\.[(a-zA-Z0-9)]{1,3}\Z', '', filename)
         if filename not in wantedroms:
             wantedroms.append(filename)


### PR DESCRIPTION
Fixes #7 

Not 100% sure if this is a perfect fix, but after looking through a couple of datfiles this seems to be more consistent than looking for the `rom` element.