### PR TITLE
feat: dump to text instead of download

### DIFF
--- a/dltool.py
+++ b/dltool.py
@@ -85,7 +85,10 @@ parser = argparse.ArgumentParser(
 #Add required arguments
 requiredargs = parser.add_argument_group('\033[91mRequired arguments\033[00m')
 requiredargs.add_argument('-i', dest='inp', metavar='nointro.dat', help='Input DAT-file containing wanted ROMs', required=True)
-requiredargs.add_argument('-o', dest='out', metavar='/data/roms', help='Output path for ROM files to be downloaded', required=True)
+required_output_group = requiredargs.add_mutually_exclusive_group(required=True)
+required_output_group.add_argument('-o', dest='out', metavar='/data/roms', help='Output path for ROM files to be downloaded')
+required_output_group.add_argument('-t', dest='text_file', metavar='rom_urls.txt', help='Output text file to write URLs of found ROMs instead of downloading them')
+
 #Add optional arguments
 optionalargs = parser.add_argument_group('\033[96mOptional arguments\033[00m')
 optionalargs.add_argument('-c', dest='catalog', action='store_true', help='Choose catalog manually, even if automatically found')
@@ -108,12 +111,12 @@ foundcollections = []
 if not os.path.isfile(args.inp):
     logger('Invalid input DAT-file!', 'red')
     exit()
-if not os.path.isdir(args.out):
+if not args.text_file and not os.path.isdir(args.out):
     logger('Invalid output ROM path!', 'red')
     exit()
 
 # Clean arguments
-args.out = args.out.rstrip(PATH_SEPARATOR)
+if args.out: args.out = args.out.rstrip(PATH_SEPARATOR)
 
 #Open input DAT-file
 logger('Opening input DAT-file...', 'green')
@@ -238,6 +241,14 @@ logger(f'Amount of wanted ROMs in DAT-file   : {len(wantedroms)}', 'green')
 logger(f'Amount of found ROMs at server      : {len(wantedfiles)}', 'green')
 if missingroms:
     logger(f'Amount of missing ROMs at server    : {len(missingroms)}', 'yellow')
+
+
+if args.text_file:
+    with open(args.text_file, 'w') as f:
+        for wantedfile in wantedfiles:
+            f.write(wantedfile['url'] + '\n')
+    logger(f'URLs dumped to {args.text_file}', 'green')
+    exit()
 
 #Download wanted files
 if not args.list:

--- a/dltool.py
+++ b/dltool.py
@@ -31,6 +31,9 @@ REQHEADERS = {
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7'
 }
 
+UNIX_SYSTEMS = {'Linux', 'Darwin'}
+PATH_SEPARATOR = '/' if platform.system() in UNIX_SYSTEMS else '\\'
+
 #Print output function
 def logger(str, color=None, rewrite=False):
     colors = {'red': '\033[91m', 'green': '\033[92m', 'yellow': '\033[93m', 'cyan': '\033[96m'}
@@ -108,10 +111,9 @@ if not os.path.isfile(args.inp):
 if not os.path.isdir(args.out):
     logger('Invalid output ROM path!', 'red')
     exit()
-if platform.system() == 'Linux' and args.out[-1] == '/':
-    args.out = args.out[:-1]
-elif platform.system() == 'Windows' and args.out[-1] == '\\':
-    args.out = args.out[:-1]
+
+# Clean arguments
+args.out = args.out.rstrip(PATH_SEPARATOR)
 
 #Open input DAT-file
 logger('Opening input DAT-file...', 'green')
@@ -245,10 +247,7 @@ if not args.list:
         resumedl = False
         proceeddl = True
         
-        if platform.system() == 'Linux':
-            localpath = f'{args.out}/{wantedfile["file"]}'
-        elif platform.system() == 'Windows':
-            localpath = f'{args.out}\{wantedfile["file"]}'
+        localpath = f'{args.out}{PATH_SEPARATOR}{wantedfile["file"]}'
         
         resp = requests.get(wantedfile['url'], headers=REQHEADERS, stream=True)
         remotefilesize = int(resp.headers.get('content-length'))


### PR DESCRIPTION
Adds an option `-t <textfile.txt>` to write each URL as a line in `<textfile.txt>`, for importing into a separate download manager (e.g. JDownloader).

The base branch for this is https://github.com/kosmosnautti/dltool/pull/15 so I could test it, so that should merge first.